### PR TITLE
Add home dir access for .engima

### DIFF
--- a/org.nongnu.enigma.yml
+++ b/org.nongnu.enigma.yml
@@ -8,7 +8,7 @@ rename-appdata-file: enigma.appdata.xml
 rename-desktop-file: enigma.desktop
 
 finish-args:
-  - --persist=.enigma
+  - --filesystem=~/.enigma
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=fallback-x11

--- a/org.nongnu.enigma.yml
+++ b/org.nongnu.enigma.yml
@@ -8,7 +8,7 @@ rename-appdata-file: enigma.appdata.xml
 rename-desktop-file: enigma.desktop
 
 finish-args:
-  - --filesystem=~/.enigma
+  - --filesystem=~/.enigma:create
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=fallback-x11


### PR DESCRIPTION
Related to [issue](https://github.com/flathub/org.nongnu.enigma/issues/10), controlled the access feature from Flatpak. It was initially used wrong. Testing new functionality and resolve issue.